### PR TITLE
TLDR: `weak_dylib_command` is born

### DIFF
--- a/macholib/mach_o.py
+++ b/macholib/mach_o.py
@@ -864,6 +864,10 @@ class dylib_command(Structure):
         return s
 
 
+class weak_dylib_command(dylib_command):
+    pass
+
+
 class sub_framework_command(Structure):
     _fields_ = (("umbrella", lc_str),)
 
@@ -1333,7 +1337,7 @@ LC_REGISTRY = {
     LC_LOADFVMLIB: fvmlib_command,
     LC_ID_DYLIB: dylib_command,
     LC_LOAD_DYLIB: dylib_command,
-    LC_LOAD_WEAK_DYLIB: dylib_command,
+    LC_LOAD_WEAK_DYLIB: weak_dylib_command,
     LC_SUB_FRAMEWORK: sub_framework_command,
     LC_SUB_CLIENT: sub_client_command,
     LC_SUB_UMBRELLA: sub_umbrella_command,


### PR DESCRIPTION
## Problem
I'm writing a script to extract `LC_LOAD_WEAK_DYLIB` from a binary, and since we only use `dylib_command` class for all types of dylib, I cannot differentiate between a regular dylib from the weak one.

## Solution
Make a new class `weak_dylib_command`, and assign that class as `LC_LOAD_WEAK_DYLIB`'s registry