### PR TITLE
Add support for finding dylibs in new macOS lib paths

### DIFF
--- a/macholib_tests/test_dyld.py
+++ b/macholib_tests/test_dyld.py
@@ -580,6 +580,12 @@ class TestTrivialDyld(unittest.TestCase):
             "/System/Library/Frameworks/System.framework/System",
         )
 
+    def testReal(self):
+        if os.getenv("READ_REAL_DYLIB", "no") == "yes":
+            return
+        info = dyld.dyld_find("libuv.dylib")
+        self.assertTrue(os.path.exists(info))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a helper function `_dyld_find_in_new_macos_lib_path` to locate dynamic libraries in new default locations used by homebrew on newer macOS versions. This change improves compatibility with macOS environments, particularly on Apple Silicon.